### PR TITLE
feat: npm install --save eq8-core@1.0.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -18,20 +18,20 @@
       }
     },
     "eq8-core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/eq8-core/-/eq8-core-0.1.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eq8-core/-/eq8-core-1.0.0.tgz",
       "dependencies": {
         "async": {
-          "version": "2.0.0-rc.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.0.0-rc.3.tgz"
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz"
         },
         "lodash": {
-          "version": "4.11.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.11.2.tgz"
+          "version": "4.16.6",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz"
         },
         "winston": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/winston/-/winston-2.2.0.tgz",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.0.tgz",
           "dependencies": {
             "async": {
               "version": "1.0.0",
@@ -52,10 +52,6 @@
             "isstream": {
               "version": "0.1.2",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            },
-            "pkginfo": {
-              "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "async": "2.0.1",
     "bloomrun": "2.1.3",
-    "eq8-core": "0.1.0",
+    "eq8-core": "1.0.0",
     "joi": "9.0.4",
     "lodash": "4.15.0",
     "rx": "4.1.0"


### PR DESCRIPTION
BREAKING CHANGE: `Core#trigger` and `Core#search` has been replaced. See https://github.com/eq8/eq8-core/releases/tag/v1.0.0